### PR TITLE
[plugin] report DOWN port status as warning

### DIFF
--- a/src/tests/unit/test_check_resources.py
+++ b/src/tests/unit/test_check_resources.py
@@ -21,6 +21,7 @@ class FakeResource:
         self._type = type_
         self._id = id_
         self.status = status
+        self.device_id = "fake_device_id"
         for key, value in kwargs.items():
             setattr(self, key, value)
 


### PR DESCRIPTION
This switches port status to WARNING from CRITICAL if their instances were shutdown.

Closes: #179