### PR TITLE
[plugin] handle unknown exceptions when checking device ids

### DIFF
--- a/files/plugins/check_resources.py
+++ b/files/plugins/check_resources.py
@@ -310,12 +310,14 @@ def mechanism_warning_ids(connection, resource_type) -> Dict[str, str]:
                     server = connection.compute.get_server(port.device_id)
                     if server.power_state == 4:  # 4 is SHUTOFF state
                         warn_ids[port.id] = "SHUTOFF"
-            except openstack.exceptions.ResourceNotFound:
-                # device_id won't be available for internal ports, and we don't
-                # expect them to be shutdown deliberately either. Basically,
-                # for any reason, if power_state can't be determined, we ignore
-                # them, and they'll be reported as CRITICAL as before.
-                pass
+            # If device_id isn't available (e.g. internal ports) or
+            # some other error occurred. Basically, for any reason,
+            # if power_state can't be determined, we ignore
+            # them, and they'll be reported as CRITICAL as before.
+            except openstack.exception.ResourceNotFound:
+                logger.info(f"'device_id' not found for port {port.id}")
+            except Exception as e:
+                logger.error(f"Unexpected error: {e}")
 
     return warn_ids
 


### PR DESCRIPTION
Although get_server() is documented to return NotFoundException which is an alias for ResourceNotFound [0], it does report different errors at times.

(Recently ResourceNotFound has been aliased as NotFoundException [1]).

In a user environment, it's returned ValueError. While it's been fixed in OpenStack [2], I don't see any why we need to differentiate the different possible exceptions here. In this plugin, we try to classify a port-down as 'warning' if we can determine their instances were shutdown; otherwise classify them as 'critical'.
If, for whatever reason, we can't detertmine the reason for a port being down, the status defaults to 'critical'.

[0] https://docs.openstack.org/openstacksdk/latest/user/proxies/compute.html
[1] https://github.com/openstack/openstacksdk/commit/14c1ebbeb8e6d7f89bd96476e6fca8ce822aebad
[2] https://github.com/openstack/openstacksdk/commit/fd2c41c69715ba39588c18224aef4e8734ed3ce1