### PR TITLE
Pin pbr to fix install

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,11 +3,7 @@ parts:
   charm:
     source: src
     plugin: reactive
-    # using charm/3.x/stable will cause the charm unable to install on 18.04
-    # with the following error: "pip requires Python '>=3.7' but the running
-    # Python is 3.6.9". This is because charm/3.x/stable start using system
-    # installation of python instead of a python snap.
-    build-snaps: [charm/2.x/stable]
+    build-snaps: [charm/3.x/stable]
 bases:
     - build-on:
         - name: ubuntu

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,3 +1,5 @@
 setuptools
 setuptools_scm[toml]
+# NOTE: pbr 6.1.1 introduced a dependency on setuptools>=64, which is not available in the build environment constraints.
+pbr==6.1.0
 flit_core<4,>=3.2.0


### PR DESCRIPTION
pbr release 6.1.1 added setuptools >= 64.0.0 as a build dependency. However, due to other constraints the maximum version of setuptools available to install is 59.6.0.