### PR TITLE
Add nrpe blocked status to tests.yaml

### DIFF
--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -15,6 +15,9 @@ target_deploy_status:
   ceph-radosgw:
     workload-status: blocked
     workload-status-message-prefix: "Missing relations: mon"
+  nrpe:
+    workload-status: blocked
+    workload-status-message-prefix: "Nagios server not configured or related"
 tests:
   - tests.test_deploy.TestOpenStackServiceChecks
   - tests.test_deploy.TestOpenStackServiceChecksCinder


### PR DESCRIPTION
Functional test failed due to mismatch in NRPE status. [See](https://github.com/canonical/charm-openstack-service-checks/actions/runs/15244376636/job/42881190393#:~:text=232-,2025%2D05%2D26%2008%3A51%3A36%20%5BINFO%5D%20Timed%20out%20waiting%20for,233,-Error%3A%20%2D26). 

A blocked status is probably now more consistent for NRPE without a Nagios server, as in https://github.com/canonical/charm-nrpe/pull/223, so it is set to be expected.